### PR TITLE
Fixed addFromArray behaviour and provided new setItems method for previous behaviour

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+.idea*
+
+vendor/*
+
+composer.lock
+composer.phar

--- a/Feed/Feed.php
+++ b/Feed/Feed.php
@@ -81,11 +81,23 @@ class Feed
     }
 
     /**
-     * Set items from array
+     * Add items from array
      *
-     * @param array $items  Array of items to add to the feed
+     * @param array|ItemInterface[] $items  Array of items to add to the feed
      */
     public function addFromArray(array $items)
+    {
+        foreach ($items as $item) {
+            $this->add($item);
+        }
+    }
+
+    /**
+     * Set items from array. Note that this method will override any existing items
+     *
+     * @param array|ItemInterface[] $items  Array of items to set
+     */
+    public function setItems(array $items)
     {
         $this->items = $items;
     }

--- a/Tests/Feed/FeedTest.php
+++ b/Tests/Feed/FeedTest.php
@@ -68,14 +68,55 @@ class FeedTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * Check if multiple items are correctly loaded
+     * Check if items are correctly added
      */
-    public function testSetItems()
+    public function testAdditemsFromEmpty()
     {
         $feed = $this->manager->get('article');
 
         $items = array(new FakeEntity(), new FakeEntity());
         $feed->addFromArray($items);
+
+        $this->assertEquals(2, count($feed->getItems()));
+    }
+
+    /**
+     * Check if items are correctly added
+     */
+    public function testAdditemsWithExistingItem()
+    {
+        $feed = $this->manager->get('article');
+        $feed->add(new FakeEntity());
+
+        $items = array(new FakeEntity(), new FakeEntity());
+        $feed->addFromArray($items);
+
+        $this->assertEquals(3, count($feed->getItems()));
+    }
+
+    /**
+     * Check if multiple items are correctly loaded
+     */
+    public function testSetItemsFromEmpty()
+    {
+        $feed = $this->manager->get('article');
+
+        $items = array(new FakeEntity(), new FakeEntity());
+        $feed->setItems($items);
+
+        $this->assertEquals(2, count($feed->getItems()));
+    }
+
+    /**
+     * Check if multiple items are correctly loaded
+     */
+    public function testSetItemsWithExistingItem()
+    {
+        $feed = $this->manager->get('article');
+        $feed->add(new FakeEntity());
+
+        $items = array(new FakeEntity(), new FakeEntity());
+        $feed->setItems($items);
 
         $this->assertEquals(2, count($feed->getItems()));
     }


### PR DESCRIPTION
I noticed the addFromArray method was actually a setter rather than being a shortcut for adding several items at once. I've fixed this and also added a new setItems method to provide the previous behaviour. Added/tweaked unit tests accordingly.
