### PR TITLE
Replace router by routerinterface

### DIFF
--- a/Feed/Feed.php
+++ b/Feed/Feed.php
@@ -16,7 +16,7 @@ use Eko\FeedBundle\Item\RoutedItemInterface;
 use Eko\FeedBundle\Formatter\RssFormatter;
 use Eko\FeedBundle\Item\Field;
 use Eko\FeedBundle\Item\ItemInterface;
-use Symfony\Bundle\FrameworkBundle\Routing\Router;
+use Symfony\Component\Routing\RouterInterface;
 
 /**
  * Feed
@@ -28,7 +28,7 @@ use Symfony\Bundle\FrameworkBundle\Routing\Router;
 class Feed
 {
     /**
-     * @var Router Router service
+     * @var RouterInterface Router service
      */
     protected $router;
 
@@ -58,9 +58,9 @@ class Feed
     /**
      * Set the router service
      *
-     * @param \Symfony\Bundle\FrameworkBundle\Routing\Router $router
+     * @param RouterInterface $router
      */
-    public function setRouter(Router $router)
+    public function setRouter(RouterInterface $router)
     {
         $this->router = $router;
     }

--- a/Feed/FeedManager.php
+++ b/Feed/FeedManager.php
@@ -10,7 +10,7 @@
 
 namespace Eko\FeedBundle\Feed;
 
-use Symfony\Bundle\FrameworkBundle\Routing\Router;
+use Symfony\Component\Routing\RouterInterface;
 
 /**
  * FeedManager
@@ -32,16 +32,17 @@ class FeedManager
     protected $feeds;
 
     /**
-     * @var \Symfony\Bundle\FrameworkBundle\Routing\Router Router service
+     * @var RouterInterface Router service
      */
     protected $router;
 
     /**
      * Constructor
-     *
-     * @param array $config Configuration settings
+     * 
+     * @param RouterInterface $router
+     * @param array           $config Configuration settings
      */
-    public function __construct(Router $router, array $config)
+    public function __construct(RouterInterface $router, array $config)
     {
         $this->config = $config;
         $this->router = $router;

--- a/Item/ProxyItem.php
+++ b/Item/ProxyItem.php
@@ -11,7 +11,7 @@
 
 namespace Eko\FeedBundle\Item;
 
-use Symfony\Bundle\FrameworkBundle\Routing\Router;
+use Symfony\Component\Routing\RouterInterface;
 
 /**
  * Proxy Item
@@ -28,7 +28,7 @@ class ProxyItem implements ItemInterface
     protected $item;
 
     /**
-     * @var Router
+     * @var RouterInterface
      */
     protected $router;
 
@@ -36,8 +36,9 @@ class ProxyItem implements ItemInterface
      * Constructor
      *
      * @param RoutedItemInterface $item
+     * @param RouterInterface     $router
      */
-    public function __construct(RoutedItemInterface $item, Router $router)
+    public function __construct(RoutedItemInterface $item, RouterInterface $router)
     {
         $this->item = $item;
         $this->router = $router;

--- a/Tests/Format/AtomFormatterTest.php
+++ b/Tests/Format/AtomFormatterTest.php
@@ -169,7 +169,7 @@ class AtomFormatterTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * Returns Router mock
+     * Returns RouterInterface mock
      *
      * @return \PHPUnit_Framework_MockObject_MockObject
      */


### PR DESCRIPTION
Change router to routerinterface in case we want to use custom router in...stead of Symfony\Bundle\FrameworkBundle\Routing\Router
