### PR TITLE
Do not limit to Symfony 2.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     ],
     "require": {
         "php": ">=5.3.2",
-        "symfony/framework-bundle": ">=2.0,<2.4-dev",
+        "symfony/framework-bundle": "~2.0",
         "zendframework/zend-feed": ">=2.0",
         "zendframework/zend-servicemanager": ">=2.0",
         "zendframework/zend-http": ">=2.0"


### PR DESCRIPTION
As of symfony 2.3, there are _no_ BC breaks in the 2.\* serie, so do not limit to the next release.

> This will make me able to test the CMF with Symfony 2.4.
