### PR TITLE
Add hydrators to populate entities

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -34,6 +34,7 @@ class Configuration implements ConfigurationInterface
 
         $rootNode
             ->children()
+                ->scalarNode('hydrator')->defaultValue('eko_feed.hydrator.default')->end()
                 ->arrayNode('feeds')
                     ->requiresAtLeastOneElement()
                     ->useAttributeAsKey('name')

--- a/DependencyInjection/EkoFeedExtension.php
+++ b/DependencyInjection/EkoFeedExtension.php
@@ -35,8 +35,30 @@ class EkoFeedExtension extends Extension
         $config = $this->processConfiguration(new Configuration(), $configs);
 
         $loader = new Loader\XmlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
-        $loader->load('services.xml');
+        $loader->load('feed.xml');
+        $loader->load('formatter.xml');
+        $loader->load('hydrator.xml');
 
         $container->setParameter('eko_feed.config', $config);
+
+        $this->configureHydrator($config, $container);
+    }
+
+    /**
+     * Configures feed reader hydrator service
+     *
+     * @param array            $config    Bundle configuration values array
+     * @param ContainerBuilder $container A ContainerBuilder instance
+     *
+     * @throws \RuntimeException
+     */
+    protected function configureHydrator(array $config, ContainerBuilder $container)
+    {
+        if (!$container->hasDefinition($config['hydrator'])) {
+            throw new \RuntimeException(sprintf('Unable to load hydrator service "%s"', $config['hydrator']));
+        }
+
+        $container->getDefinition('eko_feed.feed.reader')
+            ->setArguments(array($config['hydrator']));
     }
 }

--- a/Hydrator/DefaultHydrator.php
+++ b/Hydrator/DefaultHydrator.php
@@ -1,0 +1,52 @@
+<?php
+/*
+ * This file is part of the Eko\FeedBundle Symfony bundle.
+ *
+ * (c) Vincent Composieux <vincent.composieux@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Eko\FeedBundle\Hydrator;
+
+use Eko\FeedBundle\Item\Reader\ItemInterface;
+
+use Zend\Feed\Reader\Feed\FeedInterface;
+
+/**
+ * DefaultHydrator
+ *
+ * This is the default feed hydrator
+ *
+ * @author Vincent Composieux <vincent.composieux@gmail.com>
+ */
+class DefaultHydrator implements HydratorInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function hydrate(FeedInterface $feed, $entityName)
+    {
+        $items = array();
+
+        foreach ($feed as $entry) {
+            $entity = new $entityName();
+
+            if (!$entity instanceof ItemInterface) {
+                throw new \RuntimeException(
+                    sprintf('Entity "%s" does not implement required %s.', $entityName, 'Eko\FeedBundle\Item\Reader\ItemInterface')
+                );
+            }
+
+            $entity->setFeedItemTitle($entry->getTitle());
+            $entity->setFeedItemDescription($entry->getContent());
+            $entity->setFeedItemLink($entry->getLink());
+            $entity->setFeedItemPubDate($entry->getDateModified());
+
+            $items[] = $entity;
+        }
+
+        return $items;
+    }
+}

--- a/Hydrator/HydratorInterface.php
+++ b/Hydrator/HydratorInterface.php
@@ -1,0 +1,33 @@
+<?php
+/*
+ * This file is part of the Eko\FeedBundle Symfony bundle.
+ *
+ * (c) Vincent Composieux <vincent.composieux@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Eko\FeedBundle\Hydrator;
+
+use Zend\Feed\Reader\Feed\FeedInterface;
+
+/**
+ * HydratorInterface
+ *
+ * @author Vincent Composieux <vincent.composieux@gmail.com>
+ */
+interface HydratorInterface
+{
+    /**
+     * Hydrates given entity from its name with Feed data retrieved from reader
+     *
+     * @param FeedInterface $feed       A Feed instance
+     * @param string        $entityName An entity name to populate with feed entries
+     *
+     * @return array
+     *
+     * @throws \RuntimeException if entity does not implements ItemInterface
+     */
+    public function hydrate(FeedInterface $feed, $entityName);
+}

--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ The following configuration lines are required:
 
 ```yaml
 eko_feed:
+    hydrator: your_hydrator.custom.service # Optional, if you use entity hydrating with a custom hydrator
     feeds:
         article:
             title:       'My articles/posts'
@@ -341,6 +342,19 @@ $items = $reader->load('http://php.net/feed.atom')->populate('MyNamespace\Entity
 ```
 
 In this example, `$items` will be an array that will contains an array with your entities populated with the given feed content.
+
+### Use a custom hydrator to populate your entity
+
+You can also write your own hydrator and use it this way:
+
+```php
+$reader = $this->get('eko_feed.feed.reader');
+$reader->setHydrator(new MyCustomHydrator());
+
+$items = $reader->load('http://php.net/feed.atom')->populate('MyNamespace\Entity\Name');
+```
+
+This way, your custom hydrator will be used instead of the `Eko\FeedBundle\Hydrator\DefaultHydrator`
 
 Contributors
 ------------

--- a/Resources/config/feed.xml
+++ b/Resources/config/feed.xml
@@ -8,8 +8,6 @@
         <parameter key="eko_feed.feed.manager.class">Eko\FeedBundle\Feed\FeedManager</parameter>
         <parameter key="eko_feed.feed.class">Eko\FeedBundle\Feed\Feed</parameter>
         <parameter key="eko_feed.feed.reader.class">Eko\FeedBundle\Feed\Reader</parameter>
-        <parameter key="eko_feed.formatter.rss.class">Eko\EkoBundle\Formatter\RssFormatter</parameter>
-        <parameter key="eko_feed.formatter.atom.class">Eko\EkoBundle\Formatter\AtomFormatter</parameter>
     </parameters>
 
     <services>
@@ -18,23 +16,13 @@
             <argument>%eko_feed.config%</argument>
         </service>
 
-        <service id="eko_feed.feed.reader" class="%eko_feed.feed.reader.class%">
-            <argument type="service" id="eko_feed.feed" />
-        </service>
+        <service id="eko_feed.feed.reader" class="%eko_feed.feed.reader.class%" />
 
         <service id="eko_feed.feed" class="%eko_feed.feed.class%">
             <argument />
             <call method="setRouter">
                 <argument type="service" id="router" />
             </call>
-        </service>
-
-        <service id="eko_feed.formatter.rss" class="%eko_feed.formatter.rss.class%">
-            <argument type="service" id="eko_feed.feed" />
-        </service>
-
-        <service id="eko_feed.formatter.atom" class="%eko_feed.formatter.atom.class%">
-            <argument type="service" id="eko_feed.feed" />
         </service>
     </services>
 

--- a/Resources/config/formatter.xml
+++ b/Resources/config/formatter.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" ?>
+
+<container xmlns="http://symfony.com/schema/dic/services"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+
+    <parameters>
+        <parameter key="eko_feed.formatter.rss.class">Eko\FeedBundle\Formatter\RssFormatter</parameter>
+        <parameter key="eko_feed.formatter.atom.class">Eko\FeedBundle\Formatter\AtomFormatter</parameter>
+    </parameters>
+
+    <services>
+        <service id="eko_feed.formatter.rss" class="%eko_feed.formatter.rss.class%">
+            <argument type="service" id="eko_feed.feed" />
+        </service>
+
+        <service id="eko_feed.formatter.atom" class="%eko_feed.formatter.atom.class%">
+            <argument type="service" id="eko_feed.feed" />
+        </service>
+    </services>
+
+</container>

--- a/Resources/config/hydrator.xml
+++ b/Resources/config/hydrator.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" ?>
+
+<container xmlns="http://symfony.com/schema/dic/services"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+
+    <parameters>
+        <parameter key="eko_feed.hydrator.default.class">Eko\FeedBundle\Hydrator\DefaultHydrator</parameter>
+    </parameters>
+
+    <services>
+        <service id="eko_feed.hydrator.default" class="%eko_feed.hydrator.default.class%" />
+    </services>
+
+</container>

--- a/Tests/Feed/FeedManagerTest.php
+++ b/Tests/Feed/FeedManagerTest.php
@@ -8,7 +8,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Eko\FeedBundle\Tests;
+namespace Eko\FeedBundle\Tests\Feed;
 
 use Eko\FeedBundle\Feed\FeedManager;
 
@@ -19,7 +19,7 @@ use Eko\FeedBundle\Feed\FeedManager;
  *
  * @author Vincent Composieux <vincent.composieux@gmail.com>
  */
-class ConfigurationTest extends \PHPUnit_Framework_TestCase
+class FeedManagerTest extends \PHPUnit_Framework_TestCase
 {
     /**
      * @var FeedManager $manager A feed manager instance
@@ -27,9 +27,9 @@ class ConfigurationTest extends \PHPUnit_Framework_TestCase
     protected $manager;
 
     /**
-     * Construct elements used in test case
+     * Sets up manager & configuration used in test cases
      */
-    public function __construct() {
+    public function setUp() {
         $config = array(
             'feeds' => array(
                 'article' => array(

--- a/Tests/Feed/FeedTest.php
+++ b/Tests/Feed/FeedTest.php
@@ -8,7 +8,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Eko\FeedBundle\Tests;
+namespace Eko\FeedBundle\Tests\Feed;
 
 use Eko\FeedBundle\Feed\FeedManager;
 use Eko\FeedBundle\Tests\Entity\Writer\FakeItemInterfaceEntity;

--- a/Tests/Feed/ReaderTest.php
+++ b/Tests/Feed/ReaderTest.php
@@ -8,9 +8,10 @@
  * file that was distributed with this source code.
  */
 
-namespace Eko\FeedBundle\Tests;
+namespace Eko\FeedBundle\Tests\Feed;
 
 use Eko\FeedBundle\Feed\Reader;
+use Eko\FeedBundle\Hydrator\DefaultHydrator;
 
 /**
  * ReaderTest
@@ -27,10 +28,11 @@ class ReaderTest extends \PHPUnit_Framework_TestCase
     protected $reader;
 
     /**
-     * Construct elements used in test case
+     * Sets up elements used in test case
      */
-    public function __construct() {
+    public function setUp() {
         $this->reader = new Reader();
+        $this->reader->setHydrator(new DefaultHydrator());
     }
 
     /**

--- a/Tests/Formatter/AtomFormatterTest.php
+++ b/Tests/Formatter/AtomFormatterTest.php
@@ -8,7 +8,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Eko\FeedBundle\Tests;
+namespace Eko\FeedBundle\Tests\Formatter;
 
 use Eko\FeedBundle\Feed\FeedManager;
 use Eko\FeedBundle\Field\Channel\ChannelField;
@@ -34,9 +34,9 @@ class AtomFormatterTest extends \PHPUnit_Framework_TestCase
     protected $manager;
 
     /**
-     * Construct elements used in test case
+     * Sets up elements used in test case
      */
-    public function __construct() {
+    public function setUp() {
         $config = array(
             'feeds' => array(
                 'article' => array(

--- a/Tests/Formatter/RSSFormatterTest.php
+++ b/Tests/Formatter/RSSFormatterTest.php
@@ -8,7 +8,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Eko\FeedBundle\Tests;
+namespace Eko\FeedBundle\Tests\Formatter;
 
 use Eko\FeedBundle\Feed\FeedManager;
 use Eko\FeedBundle\Field\Channel\ChannelField;
@@ -34,9 +34,9 @@ class RSSFormatterTest extends \PHPUnit_Framework_TestCase
     protected $manager;
 
     /**
-     * Construct elements used in test case
+     * Sets up elements used in test case
      */
-    public function __construct() {
+    public function setUp() {
         $config = array(
             'feeds' => array(
                 'article' => array(


### PR DESCRIPTION
I've added a way to write custom entity hydrators.

When you load feeds from XML files into a `Feed` instance and want to make it stick into your entity, you may need to write a custom hydrator. Now, you can do it.

If you have only one custom hydrator, just specify your custom hydrator service identifier in the bundle configuration like this:

``` yaml
eko_feed:
    hydrator: your_hydrator.custom.service # Optional, if you use entity hydrating with a custom hydrator
    ...
```

Maybe you have multiple hydrators, then, you can use your custom hydrators in PHP like this:

``` php
$reader = $this->get('eko_feed.feed.reader');
$reader->setHydrator(new MyCustomHydrator());

$items = $reader->load('http://php.net/feed.atom')->populate('MyNamespace\Entity\Name');
```

Hope it can help some people to be more flexible with their feeds :)
