### PR TITLE
Fix translation of title and description in RSS formatter

### DIFF
--- a/Formatter/RssFormatter.php
+++ b/Formatter/RssFormatter.php
@@ -74,11 +74,11 @@ class RssFormatter extends Formatter implements FormatterInterface
         $channel = $root->appendChild($channel);
 
         $title = $this->translate($this->feed->get('title'));
-        $title = $this->dom->createElement('title', $this->feed->get($title));
+        $title = $this->dom->createElement('title', $title);
         $channel->appendChild($title);
 
         $description = $this->translate($this->feed->get('description'));
-        $description = $this->dom->createElement('description', $this->feed->get($description));
+        $description = $this->dom->createElement('description', $description);
         $channel->appendChild($description);
 
         $link = $this->dom->createElement('link', $this->feed->get('link'));


### PR DESCRIPTION
Hi,

Thanks for the recent feature of being able to translate titles and descriptions for feeds, it's really useful. Unfortunately it seems to have gone awry for the the RSS formatter, I think this should be the fix.
