### PR TITLE
Changed behavior of UrlGenerator to remove deprecations

### DIFF
--- a/Feed/Feed.php
+++ b/Feed/Feed.php
@@ -15,6 +15,7 @@ use Eko\FeedBundle\Field\Item\ItemFieldInterface;
 use Eko\FeedBundle\Item\Writer\ItemInterface;
 use Eko\FeedBundle\Item\Writer\ProxyItem;
 use Eko\FeedBundle\Item\Writer\RoutedItemInterface;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Symfony\Component\Routing\RouterInterface;
 
 /**
@@ -123,7 +124,7 @@ class Feed
             return (is_string($linkConfig)) ? $linkConfig : $linkConfig['uri'];
         }
 
-        return $this->router->generate($linkConfig['route_name'], $linkConfig['route_params'], true);
+        return $this->router->generate($linkConfig['route_name'], $linkConfig['route_params'], UrlGeneratorInterface::ABSOLUTE_URL);
     }
 
     /**

--- a/Item/Writer/ProxyItem.php
+++ b/Item/Writer/ProxyItem.php
@@ -11,6 +11,7 @@
 
 namespace Eko\FeedBundle\Item\Writer;
 
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Symfony\Component\Routing\RouterInterface;
 
 /**
@@ -92,7 +93,7 @@ class ProxyItem implements ItemInterface
     {
         $parameters = $this->item->getFeedItemRouteParameters() ?: [];
 
-        $url = $this->router->generate($this->item->getFeedItemRouteName(), $parameters, true);
+        $url = $this->router->generate($this->item->getFeedItemRouteName(), $parameters, UrlGeneratorInterface::ABSOLUTE_URL);
 
         $anchor = (string) $this->item->getFeedItemUrlAnchor();
         if ($anchor !== '') {

--- a/Tests/Formatter/AtomFormatterTest.php
+++ b/Tests/Formatter/AtomFormatterTest.php
@@ -20,6 +20,7 @@ use Eko\FeedBundle\Formatter\AtomFormatter;
 use Eko\FeedBundle\Formatter\RssFormatter;
 use Eko\FeedBundle\Tests\Entity\Writer\FakeItemInterfaceEntity;
 use Eko\FeedBundle\Tests\Entity\Writer\FakeRoutedItemInterfaceEntity;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
 /**
  * AtomFormatterTest.
@@ -459,6 +460,7 @@ EOF
 
         $mockRouter->expects($this->any())
             ->method('generate')
+            ->with('fake_route', [], UrlGeneratorInterface::ABSOLUTE_URL)
             ->will($this->returnValue('http://github.com/eko/FeedBundle/article/fake/url'));
 
         return $mockRouter;

--- a/Tests/Formatter/RSSFormatterTest.php
+++ b/Tests/Formatter/RSSFormatterTest.php
@@ -20,6 +20,7 @@ use Eko\FeedBundle\Formatter\AtomFormatter;
 use Eko\FeedBundle\Formatter\RssFormatter;
 use Eko\FeedBundle\Tests\Entity\Writer\FakeItemInterfaceEntity;
 use Eko\FeedBundle\Tests\Entity\Writer\FakeRoutedItemInterfaceEntity;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
 /**
  * RSSFormatterTest.
@@ -56,6 +57,7 @@ class RSSFormatterTest extends \PHPUnit_Framework_TestCase
 
         $router->expects($this->any())
             ->method('generate')
+            ->with('fake_route', [], UrlGeneratorInterface::ABSOLUTE_URL)
             ->will($this->returnValue('http://github.com/eko/FeedBundle/article/fake/url'));
 
         $translator = $this->getMock('Symfony\Component\Translation\TranslatorInterface');


### PR DESCRIPTION
Hello,

With Symfony 2.8, the params of the UrlGeneratorInterface are changed.
So i changed the param from true to UrlGeneratorInterface::ABSOLUTE_URL.

The new Constants are also included in Symfony 2.3, so it should work fine.

greetings from munich,
Sebastian