### PR TITLE
Fixed Warning: DOMDocument::createElement(): unterminated entity refe…

### DIFF
--- a/Formatter/Formatter.php
+++ b/Formatter/Formatter.php
@@ -306,7 +306,7 @@ class Formatter
                 $value = $value->format($format);
             }
 
-            $element = $this->dom->createElement($name, $value);
+            $element = $this->dom->createElement($name, htmlspecialchars($value));
         }
 
         $this->addAttributes($element, $field, $item);

--- a/Tests/Formatter/RSSFormatterTest.php
+++ b/Tests/Formatter/RSSFormatterTest.php
@@ -58,7 +58,7 @@ class RSSFormatterTest extends \PHPUnit_Framework_TestCase
         $router->expects($this->any())
             ->method('generate')
             ->with('fake_route', [], UrlGeneratorInterface::ABSOLUTE_URL)
-            ->will($this->returnValue('http://github.com/eko/FeedBundle/article/fake/url'));
+            ->will($this->returnValue('http://github.com/eko/FeedBundle/article/fake/url?utm_source=mysource&utm_medium=mymedium&utm_campaign=mycampaign&utm_content=mycontent'));
 
         $translator = $this->getMock('Symfony\Component\Translation\TranslatorInterface');
 
@@ -363,7 +363,7 @@ EOF
         $feed->add(new FakeRoutedItemInterfaceEntity());
 
         $output = $feed->render('atom');
-        $this->assertContains('<link href="http://github.com/eko/FeedBundle/article/fake/url#fake-anchor"/>', $output);
+        $this->assertContains('<link href="http://github.com/eko/FeedBundle/article/fake/url?utm_source=mysource&amp;utm_medium=mymedium&amp;utm_campaign=mycampaign&amp;utm_content=mycontent#fake-anchor"/>', $output);
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | "master"
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

```   
 public function getFeedItemRouteParameters()
    {
        return [
            'slug' => $this->getSlug(),
            'utm_source' =>'mysource',
            'utm_medium' =>'mymedium',
            'utm_campaign' =>'mycampaign',
            'utm_content' =>'mycontent'
        ];
    }
```
You get this error: Warning: DOMDocument::createElement(): unterminated entity reference utm_medium=mymedium&amp;utm_campaign=mycampaign&amp;utm_content=mycontent 