### PR TITLE
Update type of the project

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "eko/feedbundle",
-    "type": "library",
+    "type": "symfony-bundle",
     "description": "A Symfony bundle to build RSS feeds from entities",
     "keywords": ["feed", "bundle", "rss", "atom"],
     "homepage": "http://github.com/eko/FeedBundle",


### PR DESCRIPTION
In order to be able to add a flex recipe, the bundles should set `"type": "symfony-bundle"`: https://symfony.com/doc/current/bundles/best_practices.html#installation

| Q             | A
| ------------- | ---
| Branch?       | "master"
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| License       | MIT
