### PR TITLE
Replace zendframework with laminas

### DIFF
--- a/Command/FeedDumpCommand.php
+++ b/Command/FeedDumpCommand.php
@@ -10,12 +10,12 @@
 
 namespace Eko\FeedBundle\Command;
 
+use Laminas\Loader\Exception\RuntimeException;
 use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
-use Zend\Loader\Exception\RuntimeException;
 
 /**
  * FeedDumpCommand.

--- a/Command/FeedDumpCommand.php
+++ b/Command/FeedDumpCommand.php
@@ -10,12 +10,13 @@
 
 namespace Eko\FeedBundle\Command;
 
-use Laminas\Loader\Exception\RuntimeException;
-use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
+use Eko\FeedBundle\Service\FeedDumpService;
+use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Routing\RouterInterface;
 
 /**
  * FeedDumpCommand.
@@ -24,18 +25,35 @@ use Symfony\Component\Console\Output\OutputInterface;
  *
  * @author Vincent Composieux <composieux@ekino.com>
  */
-class FeedDumpCommand extends ContainerAwareCommand
+class FeedDumpCommand extends Command
 {
+    protected static $defaultName = 'eko:feed:dump';
+
+    /**
+     * @var RouterInterface
+     */
+    private $router;
+
+    /**
+     * @var FeedDumpService|null
+     */
+    private $feedDumpService;
+
+    public function __construct(RouterInterface $router, FeedDumpService $feedDumpService = null)
+    {
+        $this->router = $router;
+        $this->feedDumpService = $feedDumpService;
+
+        parent::__construct();
+    }
+
     /**
      * {@inheritdoc}
      */
     protected function configure()
     {
-        parent::configure();
-
         $this
             ->setDescription('Generate (dump) a feed in an XML file')
-            ->setName('eko:feed:dump')
             ->addOption('name', null, InputOption::VALUE_REQUIRED, 'Feed name defined in eko_feed configuration')
             ->addOption('entity', null, InputOption::VALUE_REQUIRED, 'Entity to use to generate the feed')
             ->addOption('filename', null, InputOption::VALUE_REQUIRED, 'Defines feed filename')
@@ -49,10 +67,13 @@ class FeedDumpCommand extends ContainerAwareCommand
     /**
      * {@inheritdoc}
      */
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
-        if (!$this->getContainer()->has('eko_feed.feed.dump')) {
-            throw new RuntimeException('The "eko_feed.feed.dump" service used in this command requires Doctrine ORM to be configured.');
+        if (null === $this->feedDumpService) {
+            throw new \RuntimeException(sprintf(
+                'The "%s" service used in this command requires Doctrine ORM to be configured.',
+                FeedDumpService::class
+            ));
         }
 
         $name = $input->getOption('name');
@@ -63,10 +84,9 @@ class FeedDumpCommand extends ContainerAwareCommand
         $direction = $input->getOption('direction');
         $orderBy = $input->getOption('orderBy');
 
-        $this->getContainer()->get('router')->getContext()->setHost($input->getArgument('host'));
+        $this->router->getContext()->setHost($input->getArgument('host'));
 
-        $feedDumpService = $this->getContainer()->get('eko_feed.feed.dump');
-        $feedDumpService
+        $this->feedDumpService
                 ->setName($name)
                 ->setEntity($entity)
                 ->setFilename($filename)
@@ -75,9 +95,11 @@ class FeedDumpCommand extends ContainerAwareCommand
                 ->setDirection($direction)
                 ->setOrderBy($orderBy);
 
-        $feedDumpService->dump();
+        $this->feedDumpService->dump();
 
         $output->writeln('<comment>done!</comment>');
-        $output->writeln(sprintf('<info>Feed has been dumped and located in "%s"</info>', $feedDumpService->getRootDir().$filename));
+        $output->writeln(sprintf('<info>Feed has been dumped and located in "%s"</info>', $this->feedDumpService->getRootDir().$filename));
+
+        return 0;
     }
 }

--- a/DependencyInjection/Compiler/FeedDumpServicePass.php
+++ b/DependencyInjection/Compiler/FeedDumpServicePass.php
@@ -10,11 +10,12 @@
 
 namespace Eko\FeedBundle\DependencyInjection\Compiler;
 
+use Eko\FeedBundle\Service\FeedDumpService;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 
 /**
- * Check if the eko_feed.feed.dump is missing dependencies
+ * Check if the Eko\FeedBundle\Service\FeedDumpService is missing dependencies
  * and if so remove the service.
  *
  * @author Lukas Kahwe Smith <smith@pooteeweet.org>
@@ -27,7 +28,7 @@ class FeedDumpServicePass implements CompilerPassInterface
     public function process(ContainerBuilder $container)
     {
         if (!$container->hasAlias('doctrine.orm.entity_manager')) {
-            $container->removeDefinition('eko_feed.feed.dump');
+            $container->removeDefinition(FeedDumpService::class);
         }
     }
 }

--- a/DependencyInjection/EkoFeedExtension.php
+++ b/DependencyInjection/EkoFeedExtension.php
@@ -39,6 +39,7 @@ class EkoFeedExtension extends Extension
         $loader->load('feed.xml');
         $loader->load('formatter.xml');
         $loader->load('hydrator.xml');
+        $loader->load('command.xml');
 
         $container->setParameter('eko_feed.config', $config);
         $container->setParameter('eko_feed.translation_domain', $config['translation_domain']);

--- a/Feed/Reader.php
+++ b/Feed/Reader.php
@@ -11,8 +11,8 @@
 namespace Eko\FeedBundle\Feed;
 
 use Eko\FeedBundle\Hydrator\HydratorInterface;
-use Zend\Feed\Reader\Feed\FeedInterface;
-use Zend\Feed\Reader\Reader as ZendReader;
+use Laminas\Feed\Reader\Feed\FeedInterface;
+use Laminas\Feed\Reader\Reader as ZendReader;
 
 /**
  * Reader.

--- a/Hydrator/DefaultHydrator.php
+++ b/Hydrator/DefaultHydrator.php
@@ -11,7 +11,7 @@
 namespace Eko\FeedBundle\Hydrator;
 
 use Eko\FeedBundle\Item\Reader\ItemInterface;
-use Zend\Feed\Reader\Feed\FeedInterface;
+use Laminas\Feed\Reader\Feed\FeedInterface;
 
 /**
  * DefaultHydrator.

--- a/Hydrator/HydratorInterface.php
+++ b/Hydrator/HydratorInterface.php
@@ -10,7 +10,7 @@
 
 namespace Eko\FeedBundle\Hydrator;
 
-use Zend\Feed\Reader\Feed\FeedInterface;
+use Laminas\Feed\Reader\Feed\FeedInterface;
 
 /**
  * HydratorInterface.

--- a/README.md
+++ b/README.md
@@ -356,14 +356,16 @@ done!
 Feed has been dumped and located in "/Users/vincent/dev/perso/symfony/web/test.xml"
 ```
 
-### Dump your feeds by using the eko_feed.feed.dump
-You can dump your feeds by simply using the "eko_feed.feed.dump" service. Used by the dump command, you have the same value to set.
+### Dump your feeds by using the Eko\FeedBundle\Service\FeedDumpService
+You can dump your feeds by simply using the "`Eko\FeedBundle\Service\FeedDumpService`" service. Used by the dump command, you have the same value to set.
 If you already have you items feed ready, you can dump it using the setItems().
 
 ```php
 <?php
 
-$feedDumpService = $this->get('eko_feed.feed.dump');
+use Eko\FeedBundle\Service\FeedDumpService;
+
+$feedDumpService = $this->get(FeedDumpService::class);
 $feedDumpService
         ->setName($name)
         //You can set an entity

--- a/Tests/Feed/ReaderTest.php
+++ b/Tests/Feed/ReaderTest.php
@@ -13,6 +13,8 @@ namespace Eko\FeedBundle\Tests\Feed;
 use Eko\FeedBundle\Feed\Reader;
 use Eko\FeedBundle\Hydrator\DefaultHydrator;
 use Eko\FeedBundle\Tests\Entity\Reader\FakeItemInterfaceEntity;
+use Laminas\Feed\Reader\Collection\Author;
+use Laminas\Feed\Reader\Feed\FeedInterface;
 
 /**
  * ReaderTest.
@@ -45,12 +47,12 @@ class ReaderTest extends \PHPUnit\Framework\TestCase
         $feed = $this->reader->load(__DIR__.'/../DataFixtures/Feed.xml')->get();
 
         $this->assertNotNull($feed, 'Returned feed should not be null');
-        $this->assertInstanceOf('\Zend\Feed\Reader\Feed\FeedInterface', $feed, 'Should return an AbstractFeed instance');
+        $this->assertInstanceOf(FeedInterface::class, $feed, 'Should return an AbstractFeed instance');
 
         foreach ($feed as $entry) {
             $this->assertEquals('PHP 5.4.11 and PHP 5.3.21 released!', $entry->getTitle(), 'Should be equal');
             $this->assertEquals('http://php.net/index.php#id2013-01-17-1', $entry->getLink(), 'Should be equal');
-            $this->assertInstanceOf('\Zend\Feed\Reader\Collection\Author', $entry->getAuthors(), 'Should be an instance of Author');
+            $this->assertInstanceOf(Author::class, $entry->getAuthors(), 'Should be an instance of Author');
         }
     }
 

--- a/composer.json
+++ b/composer.json
@@ -15,9 +15,9 @@
         "php": "^7.0",
         "symfony/framework-bundle": "^4.0|^5.0",
         "symfony/translation": "^4.0|^5.0",
-        "zendframework/zend-feed": ">=2.0",
-        "zendframework/zend-servicemanager": ">=2.0",
-        "zendframework/zend-http": ">=2.0"
+        "laminas/laminas-feed": "^2.0",
+        "laminas/laminas-servicemanager": "^2.0",
+        "laminas/laminas-http": "^2.0"
     },
     "require-dev": {
         "doctrine/orm": "~2.7",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | "master"
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | yes
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

There are two commits, the first one is because all [zendframework packages](https://packagist.org/packages/zendframework/zend-feed) are abandoned and they are replace by [laminas](https://packagist.org/packages/laminas/laminas-feed).

And the second one is because `ContainerAwareCommand` does not exist in Symfony 5.
