### PR TITLE
Add missing command.xml and remove unused packages

### DIFF
--- a/Resources/config/command.xml
+++ b/Resources/config/command.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" ?>
+
+<container xmlns="http://symfony.com/schema/dic/services"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+
+    <services>
+        <service id="Eko\FeedBundle\Command\FeedDumpCommand" autowire="false">
+            <tag name="symfony.console" />
+            <argument type="service" id="router" />
+            <argument type="service" id="Eko\FeedBundle\Feed\FeedManager" on-invalid="null" />
+        </service>
+    </services>
+
+</container>

--- a/composer.json
+++ b/composer.json
@@ -15,9 +15,7 @@
         "php": "^7.0",
         "symfony/framework-bundle": "^4.0|^5.0",
         "symfony/translation": "^4.0|^5.0",
-        "laminas/laminas-feed": "^2.0",
-        "laminas/laminas-servicemanager": "^2.0",
-        "laminas/laminas-http": "^2.0"
+        "laminas/laminas-feed": "^2.0"
     },
     "require-dev": {
         "doctrine/orm": "~2.7",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | "master"
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | https://github.com/eko/FeedBundle/issues/77, https://github.com/eko/FeedBundle/issues/78
| License       | MIT
| Doc PR        | reference to the documentation PR, if any

I missed to upload the `command.xml` file 🤦‍♂️ in https://github.com/eko/FeedBundle/pull/76

**EDIT**:

I've also removed `laminas/laminas-servicemanager` that was added in https://github.com/eko/FeedBundle/issues/20 long time ago and I guess that was fixed. [I haven't seen any reference in the code to `Laminas\ServiceManager` or `Zend\ServiceManager`](https://github.com/eko/FeedBundle/search?q=servicemanager&unscoped_q=servicemanager). And `laminas/laminas-http` that was added in https://github.com/eko/FeedBundle/commit/2264161b33a0fe19c65e3b75b24a719e8a11f8ef, but [I haven't seen any reference either](https://github.com/eko/FeedBundle/search?q=laminas%2Fhttp&unscoped_q=laminas%2Fhttp).