### PR TITLE
Fix invalid definition

### DIFF
--- a/Resources/config/feed.xml
+++ b/Resources/config/feed.xml
@@ -23,7 +23,8 @@
         <service id="Eko\FeedBundle\Feed\Reader" public="true" autowire="false" />
 
         <service id="Eko\FeedBundle\Feed\Feed" public="true" autowire="false">
-            <argument />
+            <argument type="collection"/>
+            <argument type="collection"/>
             <call method="setRouter">
                 <argument type="service" id="router" />
             </call>


### PR DESCRIPTION
Error from lint container:
./bin/console lint:container

In CheckTypeDeclarationsPass.php line 133:
Invalid definition for service "Eko\FeedBundle\Feed\Feed": "Eko\FeedBundle\Feed\Feed::__construct()" requires 2 arguments, 1 passed.

| Q             | A
| ------------- | ---
| Branch?       | "master"
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| License       | MIT
| Doc PR        | reference to the documentation PR, if any