### PR TITLE
Use a registry instead of plain PHP array for formatter registration

### DIFF
--- a/DependencyInjection/Compiler/FeedFormatterPass.php
+++ b/DependencyInjection/Compiler/FeedFormatterPass.php
@@ -10,13 +10,13 @@
 
 namespace Eko\FeedBundle\DependencyInjection\Compiler;
 
-use Eko\FeedBundle\Feed\FeedManager;
+use Eko\FeedBundle\Formatter\FormatterRegistry;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Reference;
 
 /**
- * Retrieve all formatters and inject them into the feed manager service.
+ * Retrieve all formatters and inject them into the formatter registry.
  *
  * @author Vincent Composieux <vincent.composieux@gail.com>
  */
@@ -27,16 +27,18 @@ class FeedFormatterPass implements CompilerPassInterface
      */
     public function process(ContainerBuilder $container)
     {
-        $formatters = [];
-
         $services = $container->findTaggedServiceIds('eko_feed.formatter');
+        $registry = $container->getDefinition(FormatterRegistry::class);
 
         foreach ($services as $identifier => $options) {
             $options = current($options);
-            $formatters[$options['format']] = new Reference($identifier);
+            $registry->addMethodCall(
+                'addFormatter',
+                [
+                    $options['format'],
+                    new Reference($identifier),
+                ]
+            );
         }
-
-        $manager = $container->getDefinition(FeedManager::class);
-        $manager->replaceArgument(2, $formatters);
     }
 }

--- a/Feed/Feed.php
+++ b/Feed/Feed.php
@@ -12,6 +12,7 @@ namespace Eko\FeedBundle\Feed;
 
 use Eko\FeedBundle\Field\Channel\ChannelFieldInterface;
 use Eko\FeedBundle\Field\Item\ItemFieldInterface;
+use Eko\FeedBundle\Formatter\FormatterRegistry;
 use Eko\FeedBundle\Item\Writer\ItemInterface;
 use Eko\FeedBundle\Item\Writer\ProxyItem;
 use Eko\FeedBundle\Item\Writer\RoutedItemInterface;
@@ -33,7 +34,7 @@ class Feed
     protected $config;
 
     /**
-     * @var array
+     * @var FormatterRegistry
      */
     protected $formatters;
 
@@ -60,10 +61,10 @@ class Feed
     /**
      * Constructor.
      *
-     * @param array $config     Configuration settings
-     * @param array $formatters An array of available formatters services
+     * @param array             $config     Configuration settings
+     * @param FormatterRegistry $formatters An array of available formatters services
      */
-    public function __construct(array $config, array $formatters)
+    public function __construct(array $config, FormatterRegistry $formatters)
     {
         $this->config = $config;
         $this->formatters = $formatters;
@@ -250,13 +251,13 @@ class Feed
      */
     public function render($format)
     {
-        if (!isset($this->formatters[$format])) {
+        if (!$this->formatters->supportsFormat($format)) {
             throw new \InvalidArgumentException(
                 sprintf("Unable to find a formatter service for format '%s'.", $format)
             );
         }
 
-        $formatter = $this->formatters[$format];
+        $formatter = $this->formatters->getFormatter($format);
         $formatter->setFeed($this);
 
         return $formatter->render();

--- a/Feed/FeedManager.php
+++ b/Feed/FeedManager.php
@@ -10,6 +10,7 @@
 
 namespace Eko\FeedBundle\Feed;
 
+use Eko\FeedBundle\Formatter\FormatterRegistry;
 use Symfony\Component\DependencyInjection\ContainerAwareTrait;
 use Symfony\Component\Routing\RouterInterface;
 
@@ -35,7 +36,7 @@ class FeedManager
     protected $router;
 
     /**
-     * @var array
+     * @var FormatterRegistry
      */
     protected $formatters;
 
@@ -47,11 +48,11 @@ class FeedManager
     /**
      * Constructor.
      *
-     * @param RouterInterface $router     A Symfony router instance
-     * @param array           $config     Configuration settings
-     * @param array           $formatters Feed formatters list
+     * @param RouterInterface   $router     A Symfony router instance
+     * @param array             $config     Configuration settings
+     * @param FormatterRegistry $formatters Feed formatters list
      */
-    public function __construct(RouterInterface $router, array $config, array $formatters)
+    public function __construct(RouterInterface $router, array $config, FormatterRegistry $formatters)
     {
         $this->config = $config;
         $this->router = $router;

--- a/Formatter/FormatterRegistry.php
+++ b/Formatter/FormatterRegistry.php
@@ -1,0 +1,63 @@
+<?php
+/*
+ * This file is part of the Eko\FeedBundle Symfony bundle.
+ *
+ * (c) Daniel Siepmann <coding@daniel-siepmann.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Eko\FeedBundle\Formatter;
+
+/**
+ * FormatterRegistry.
+ *
+ * This class provides all registered formatters.
+ *
+ * @author Daniel Siepmann <coding@daniel-siepmann.de>
+ */
+class FormatterRegistry
+{
+    /**
+     * @var array
+     */
+    protected $formatters = [];
+
+    /**
+     * Add a new formatter to the registry.
+     *
+     * @param string             $format    The format to render (RSS, Atom, ...)
+     * @param FormatterInterface $formatter The formatter to use for given format.
+     *
+     * @return void
+     */
+    public function addFormatter($format, $formatter)
+    {
+        $this->formatters[$format] = $formatter;
+    }
+
+    /**
+     * Returns whether the given format is supported.
+     *
+     * @param string $format The format to render (RSS, Atom, ...)
+     *
+     * @return bool
+     */
+    public function supportsFormat($format)
+    {
+        return isset($this->formatters[$format]);
+    }
+
+    /**
+     * Returns the formatter for requested format.
+     *
+     * @param string $format The format to render (RSS, Atom, ...)
+     *
+     * @return FormatterInterface
+     */
+    public function getFormatter($format)
+    {
+        return $this->formatters[$format];
+    }
+}

--- a/Resources/config/formatter.xml
+++ b/Resources/config/formatter.xml
@@ -5,6 +5,8 @@
            xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
 
     <services>
+        <service id="Eko\FeedBundle\Formatter\FormatterRegistry" autowire="false" />
+
         <service id="Eko\FeedBundle\Formatter\RssFormatter" autowire="false">
             <tag name="eko_feed.formatter" format="rss"></tag>
 

--- a/Tests/Feed/FeedManagerTest.php
+++ b/Tests/Feed/FeedManagerTest.php
@@ -12,6 +12,7 @@ namespace Eko\FeedBundle\Tests\Feed;
 
 use Eko\FeedBundle\Feed\FeedManager;
 use Eko\FeedBundle\Formatter\AtomFormatter;
+use Eko\FeedBundle\Formatter\FormatterRegistry;
 use Eko\FeedBundle\Formatter\RssFormatter;
 use Symfony\Component\Routing\RouterInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
@@ -51,12 +52,11 @@ class FeedManagerTest extends \PHPUnit\Framework\TestCase
 
         $translator = $this->createMock(TranslatorInterface::class);
 
-        $formatters = [
-            'rss'  => new RssFormatter($translator, 'test'),
-            'atom' => new AtomFormatter($translator, 'test'),
-        ];
+        $formatterRegistry = new FormatterRegistry();
+        $formatterRegistry->addFormatter('rss', new RssFormatter($translator, 'test'));
+        $formatterRegistry->addFormatter('atom', new AtomFormatter($translator, 'test'));
 
-        $this->manager = new FeedManager($router, $config, $formatters);
+        $this->manager = new FeedManager($router, $config, $formatterRegistry);
     }
 
     /**

--- a/Tests/Feed/FeedTest.php
+++ b/Tests/Feed/FeedTest.php
@@ -12,6 +12,7 @@ namespace Eko\FeedBundle\Tests\Feed;
 
 use Eko\FeedBundle\Feed\FeedManager;
 use Eko\FeedBundle\Formatter\AtomFormatter;
+use Eko\FeedBundle\Formatter\FormatterRegistry;
 use Eko\FeedBundle\Formatter\RssFormatter;
 use Eko\FeedBundle\Tests\Entity\Writer\FakeItemInterfaceEntity;
 use Symfony\Component\Routing\RouterInterface;
@@ -52,12 +53,11 @@ class FeedTest extends \PHPUnit\Framework\TestCase
 
         $translator = $this->createMock(TranslatorInterface::class);
 
-        $formatters = [
-            'rss'  => new RssFormatter($translator, 'test'),
-            'atom' => new AtomFormatter($translator, 'test'),
-        ];
+        $formatterRegistry = new FormatterRegistry();
+        $formatterRegistry->addFormatter('rss', new RssFormatter($translator, 'test'));
+        $formatterRegistry->addFormatter('atom', new AtomFormatter($translator, 'test'));
 
-        $this->manager = new FeedManager($router, $config, $formatters);
+        $this->manager = new FeedManager($router, $config, $formatterRegistry);
     }
 
     /**

--- a/Tests/Formatter/AtomFormatterTest.php
+++ b/Tests/Formatter/AtomFormatterTest.php
@@ -17,6 +17,7 @@ use Eko\FeedBundle\Field\Item\GroupItemField;
 use Eko\FeedBundle\Field\Item\ItemField;
 use Eko\FeedBundle\Field\Item\MediaItemField;
 use Eko\FeedBundle\Formatter\AtomFormatter;
+use Eko\FeedBundle\Formatter\FormatterRegistry;
 use Eko\FeedBundle\Formatter\RssFormatter;
 use Eko\FeedBundle\Tests\Entity\Writer\FakeItemInterfaceEntity;
 use Eko\FeedBundle\Tests\Entity\Writer\FakeRoutedItemInterfaceEntity;
@@ -57,12 +58,11 @@ class AtomFormatterTest extends \PHPUnit\Framework\TestCase
 
         $translator = $this->createMock(TranslatorInterface::class);
 
-        $formatters = [
-            'rss'  => new RssFormatter($translator, 'test'),
-            'atom' => new AtomFormatter($translator, 'test'),
-        ];
+        $formatterRegistry = new FormatterRegistry();
+        $formatterRegistry->addFormatter('rss', new RssFormatter($translator, 'test'));
+        $formatterRegistry->addFormatter('atom', new AtomFormatter($translator, 'test'));
 
-        $this->manager = new FeedManager($this->getMockRouter(), $config, $formatters);
+        $this->manager = new FeedManager($this->getMockRouter(), $config, $formatterRegistry);
     }
 
     /**
@@ -85,12 +85,11 @@ class AtomFormatterTest extends \PHPUnit\Framework\TestCase
 
         $translator = $this->createMock(TranslatorInterface::class);
 
-        $formatters = [
-            'rss'  => new RssFormatter($translator, 'test'),
-            'atom' => new AtomFormatter($translator, 'test'),
-        ];
+        $formatterRegistry = new FormatterRegistry();
+        $formatterRegistry->addFormatter('rss', new RssFormatter($translator, 'test'));
+        $formatterRegistry->addFormatter('atom', new AtomFormatter($translator, 'test'));
 
-        $manager = new FeedManager($this->getMockRouter(), $config, $formatters);
+        $manager = new FeedManager($this->getMockRouter(), $config, $formatterRegistry);
 
         $feed = $manager->get('article');
 
@@ -456,9 +455,10 @@ EOF
         $translator = $this->createMock(TranslatorInterface::class);
         $translator->expects($this->any())->method('trans')->will($this->returnValue('translatable-value'));
 
-        $formatters = ['atom' => new AtomFormatter($translator, 'test')];
+        $formatterRegistry = new FormatterRegistry();
+        $formatterRegistry->addFormatter('atom', new AtomFormatter($translator, 'test'));
 
-        $manager = new FeedManager($this->getMockRouter(), $config, $formatters);
+        $manager = new FeedManager($this->getMockRouter(), $config, $formatterRegistry);
 
         $feed = $manager->get('article');
         $feed->add(new FakeRoutedItemInterfaceEntity());

--- a/Tests/Formatter/FormatterRegistryTest.php
+++ b/Tests/Formatter/FormatterRegistryTest.php
@@ -1,0 +1,59 @@
+<?php
+/*
+ * This file is part of the Eko\FeedBundle Symfony bundle.
+ *
+ * (c) Daniel Siepmann <coding@daniel-siepmann.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Eko\FeedBundle\Tests\Formatter;
+
+use Eko\FeedBundle\Formatter\FormatterInterface;
+use Eko\FeedBundle\Formatter\FormatterRegistry;
+
+/**
+ * FormatterRegistryTest.
+ *
+ * This is the Formatter registry test class
+ *
+ * @author Daniel Siepmann <coding@daniel-siepmann.de>
+ */
+class FormatterRegistryTest extends \PHPUnit\Framework\TestCase
+{
+    /**
+     * Check if initial instance does not provide formatters.
+     */
+    public function testInitialStateIsEmpty()
+    {
+        $registry = new FormatterRegistry();
+
+        $this->assertFalse($registry->supportsFormat('rss'));
+        $this->assertFalse($registry->supportsFormat('atom'));
+    }
+
+    /**
+     * Check if initial instance does not provide formatters.
+     */
+    public function testSupportForAddedFormatterIsProvided()
+    {
+        $registry = new FormatterRegistry();
+        $registry->addFormatter('rss', $this->createMock(FormatterInterface::class));
+
+        $this->assertTrue($registry->supportsFormat('rss'));
+    }
+
+    /**
+     * Check if initial instance does not provide formatters.
+     */
+    public function testReturnsRequestedFormatter()
+    {
+        $formatter = $this->createMock(FormatterInterface::class);
+
+        $registry = new FormatterRegistry();
+        $registry->addFormatter('rss', $formatter);
+
+        $this->assertSame($formatter, $registry->getFormatter('rss'));
+    }
+}

--- a/Tests/Formatter/RSSFormatterTest.php
+++ b/Tests/Formatter/RSSFormatterTest.php
@@ -17,6 +17,7 @@ use Eko\FeedBundle\Field\Item\GroupItemField;
 use Eko\FeedBundle\Field\Item\ItemField;
 use Eko\FeedBundle\Field\Item\MediaItemField;
 use Eko\FeedBundle\Formatter\AtomFormatter;
+use Eko\FeedBundle\Formatter\FormatterRegistry;
 use Eko\FeedBundle\Formatter\RssFormatter;
 use Eko\FeedBundle\Tests\Entity\Writer\FakeItemInterfaceEntity;
 use Eko\FeedBundle\Tests\Entity\Writer\FakeRoutedItemInterfaceEntity;
@@ -64,12 +65,11 @@ class RSSFormatterTest extends \PHPUnit\Framework\TestCase
 
         $translator = $this->createMock(TranslatorInterface::class);
 
-        $formatters = [
-            'rss'  => new RssFormatter($translator, 'test'),
-            'atom' => new AtomFormatter($translator, 'test'),
-        ];
+        $formatterRegistry = new FormatterRegistry();
+        $formatterRegistry->addFormatter('rss', new RssFormatter($translator, 'test'));
+        $formatterRegistry->addFormatter('atom', new AtomFormatter($translator, 'test'));
 
-        $this->manager = new FeedManager($router, $config, $formatters);
+        $this->manager = new FeedManager($router, $config, $formatterRegistry);
     }
 
     /**
@@ -402,11 +402,12 @@ EOF
         $translator = $this->createMock(TranslatorInterface::class);
         $translator->expects($this->any())->method('trans')->will($this->returnValue('translatable-value'));
 
-        $formatters = ['rss' => new RssFormatter($translator, 'test')];
+        $formatterRegistry = new FormatterRegistry();
+        $formatterRegistry->addFormatter('rss', new RssFormatter($translator, 'test'));
 
         $router = $this->createMock(RouterInterface::class);
 
-        $manager = new FeedManager($router, $config, $formatters);
+        $manager = new FeedManager($router, $config, $formatterRegistry);
 
         $feed = $manager->get('article');
         $feed->add(new FakeItemInterfaceEntity());


### PR DESCRIPTION
This allows to inject the formatters in other classes.
This also eases to replace the feed manager but still receive the
formatters, as they are no longer hard injected into a specific PHP
class / service but provided via a registry.

| Q             | A
| ------------- | ---
| Branch?       | "master"
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | Gues so, signature of the FeedManager constructor has changed. Not sure if that was considered public API.
| Deprecations? | no
| Tests pass?   | yes/no
| Fixed tickets | 
| License       | MIT
| Doc PR        | 
